### PR TITLE
Fixing bug where help didn't work if the app's folder contained a space.

### DIFF
--- a/PatchMaker.App/HelpSpawner.cs
+++ b/PatchMaker.App/HelpSpawner.cs
@@ -81,7 +81,7 @@ namespace PatchMaker.App
             ProcessStartInfo sInfo = new ProcessStartInfo()
             {
                 FileName = GetDefaultBrowserPath(),
-                Arguments = $"file:///{file}"
+                Arguments = $"\"file:///{file}\""
             };
             Process.Start(sInfo);
         }


### PR DESCRIPTION
Resolves #17 