### PR TITLE
Adjust validation behaviour of attribute patch form

### DIFF
--- a/PatchMaker.App/PatchForms/PatchAttributeForm.Designer.cs
+++ b/PatchMaker.App/PatchForms/PatchAttributeForm.Designer.cs
@@ -29,33 +29,22 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PatchAttributeForm));
-            this.treeView = new PatchMaker.App.XmlFragmentTreeView();
             this.cancelBtn = new System.Windows.Forms.Button();
             this.okBtn = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.elementXPathTextBox = new PatchMaker.App.RequiredFieldTextBox();
             this.patchTypeCombo = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
-            this.nameTextBox = new PatchMaker.App.RequiredFieldTextBox();
             this.label4 = new System.Windows.Forms.Label();
             this.valueTextBox = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();
             this.defaultComboBox = new System.Windows.Forms.ComboBox();
             this.label6 = new System.Windows.Forms.Label();
             this.applyDefaultBtn = new System.Windows.Forms.Button();
+            this.nameTextBox = new PatchMaker.App.RequiredFieldTextBox();
+            this.elementXPathTextBox = new PatchMaker.App.RequiredFieldTextBox();
+            this.treeView = new PatchMaker.App.XmlFragmentTreeView();
             this.SuspendLayout();
-            // 
-            // treeView
-            // 
-            this.treeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.treeView.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.treeView.Location = new System.Drawing.Point(60, 12);
-            this.treeView.Name = "treeView";
-            this.treeView.Size = new System.Drawing.Size(624, 97);
-            this.treeView.TabIndex = 0;
             // 
             // cancelBtn
             // 
@@ -101,20 +90,10 @@
             this.label2.TabIndex = 7;
             this.label2.Text = "Element:";
             // 
-            // elementXPathTextBox
-            // 
-            this.elementXPathTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.elementXPathTextBox.EmptyFieldValidationMessage = "Field can\'t be empty";
-            this.elementXPathTextBox.Font = new System.Drawing.Font("Consolas", 8.25F);
-            this.elementXPathTextBox.Location = new System.Drawing.Point(60, 115);
-            this.elementXPathTextBox.Name = "elementXPathTextBox";
-            this.elementXPathTextBox.Size = new System.Drawing.Size(624, 20);
-            this.elementXPathTextBox.TabIndex = 1;
-            // 
             // patchTypeCombo
             // 
             this.patchTypeCombo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.patchTypeCombo.CausesValidation = false;
             this.patchTypeCombo.FormattingEnabled = true;
             this.patchTypeCombo.Location = new System.Drawing.Point(60, 141);
             this.patchTypeCombo.Name = "patchTypeCombo";
@@ -131,17 +110,6 @@
             this.label3.Size = new System.Drawing.Size(34, 13);
             this.label3.TabIndex = 9;
             this.label3.Text = "Type:";
-            // 
-            // nameTextBox
-            // 
-            this.nameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.nameTextBox.EmptyFieldValidationMessage = "Field can\'t be empty";
-            this.nameTextBox.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.nameTextBox.Location = new System.Drawing.Point(60, 168);
-            this.nameTextBox.Name = "nameTextBox";
-            this.nameTextBox.Size = new System.Drawing.Size(416, 20);
-            this.nameTextBox.TabIndex = 3;
             // 
             // label4
             // 
@@ -178,6 +146,7 @@
             // defaultComboBox
             // 
             this.defaultComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.defaultComboBox.CausesValidation = false;
             this.defaultComboBox.FormattingEnabled = true;
             this.defaultComboBox.Location = new System.Drawing.Point(528, 167);
             this.defaultComboBox.Name = "defaultComboBox";
@@ -197,6 +166,7 @@
             // applyDefaultBtn
             // 
             this.applyDefaultBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.applyDefaultBtn.CausesValidation = false;
             this.applyDefaultBtn.Location = new System.Drawing.Point(655, 165);
             this.applyDefaultBtn.Name = "applyDefaultBtn";
             this.applyDefaultBtn.Size = new System.Drawing.Size(29, 23);
@@ -204,6 +174,39 @@
             this.applyDefaultBtn.Text = "<<";
             this.applyDefaultBtn.UseVisualStyleBackColor = true;
             this.applyDefaultBtn.Click += new System.EventHandler(this.applyDefaultBtn_Click);
+            // 
+            // nameTextBox
+            // 
+            this.nameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.nameTextBox.EmptyFieldValidationMessage = "Field can\'t be empty";
+            this.nameTextBox.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.nameTextBox.Location = new System.Drawing.Point(60, 168);
+            this.nameTextBox.Name = "nameTextBox";
+            this.nameTextBox.Size = new System.Drawing.Size(416, 20);
+            this.nameTextBox.TabIndex = 3;
+            // 
+            // elementXPathTextBox
+            // 
+            this.elementXPathTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.elementXPathTextBox.EmptyFieldValidationMessage = "Field can\'t be empty";
+            this.elementXPathTextBox.Font = new System.Drawing.Font("Consolas", 8.25F);
+            this.elementXPathTextBox.Location = new System.Drawing.Point(60, 115);
+            this.elementXPathTextBox.Name = "elementXPathTextBox";
+            this.elementXPathTextBox.Size = new System.Drawing.Size(624, 20);
+            this.elementXPathTextBox.TabIndex = 1;
+            // 
+            // treeView
+            // 
+            this.treeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.treeView.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.treeView.Location = new System.Drawing.Point(60, 12);
+            this.treeView.Name = "treeView";
+            this.treeView.Size = new System.Drawing.Size(624, 97);
+            this.treeView.TabIndex = 0;
             // 
             // PatchAttributeForm
             // 


### PR DESCRIPTION
Resolves #31 by changing the "requires validation" properties of the ddl/button controls that aren't the "ok" button.