### PR TITLE
Bug/further namespace fixes

### DIFF
--- a/PatchMaker.App/Properties/AssemblyInfo.cs
+++ b/PatchMaker.App/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]

--- a/PatchMaker.App/XmlTextBox.cs
+++ b/PatchMaker.App/XmlTextBox.cs
@@ -31,6 +31,7 @@ namespace PatchMaker.App
         {
             var m = new ContextMenuStrip();
 
+            // add operations to copy any namespaces declared on the root element
             foreach(var nsAttr in root.Attributes())
             {
                 if(nsAttr.Name.NamespaceName == Namespaces.XmlnsUri)
@@ -39,7 +40,20 @@ namespace PatchMaker.App
                 }
             }
 
+            // But check to ensure that role / security are always there because they're important
+            addIfMissing(m, root, "role", Namespaces.Role);
+            addIfMissing(m, root, "security", Namespaces.Security);
+
             this.ContextMenuStrip = m;
+        }
+
+        private void addIfMissing(ContextMenuStrip m, XElement root, string name, XNamespace ns)
+        {
+            var existed = root.Attributes().Where(a => a.Value == ns.NamespaceName).Any();
+            if (!existed)
+            {
+                m.Items.Add(makeMenu(name, ns));
+            }
         }
 
         private ToolStripMenuItem makeMenu(string name, string ns)

--- a/PatchMaker.Sitecore/Properties/AssemblyInfo.cs
+++ b/PatchMaker.Sitecore/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]

--- a/PatchMaker.Tests/Properties/AssemblyInfo.cs
+++ b/PatchMaker.Tests/Properties/AssemblyInfo.cs
@@ -16,5 +16,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("fa65576f-e452-4a11-8952-fb8f35723d9a")]
 
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]

--- a/PatchMaker/BasePatch.cs
+++ b/PatchMaker/BasePatch.cs
@@ -118,11 +118,14 @@ namespace PatchMaker
             {
                 if (attr.Name.Namespace.NamespaceName == Namespaces.XmlnsUri)
                 {
+                    // when a namespace declaration exists at the patch root, just remove it from this node
+                    // otherwise copy it to the patch root and then remove it from here.
                     var match = rootNode.Attributes().Where(a => a.Value == attr.Value).Any();
-                    if (match)
+                    if (!match)
                     {
-                        attr.Remove();
+                        patchXml.Root.Add(attr);
                     }
+                    attr.Remove();
                 }
             }
         }

--- a/PatchMaker/Properties/AssemblyInfo.cs
+++ b/PatchMaker/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]


### PR DESCRIPTION
Attempts to resolve #37 and #36 with minor adjustments to namespace handling:

* If you add a custom namespace to a "new" xml element (in `patch:insert` for example) it will move this namespace to the root of your patch XML document.
* The dropdown for inserting namespaces into the `XmlTextBox` now includes your custom namespaces and the core ones for patches. It won't add core ones twice.