### PR TITLE
Bug/45 error generating patch for delete

### DIFF
--- a/PatchMaker.App/PatchProcessManager.cs
+++ b/PatchMaker.App/PatchProcessManager.cs
@@ -46,16 +46,21 @@ namespace PatchMaker.App
 
         private void mapTreeView()
         {
-            var xElement = _sourceXml.Root;
-            var rootNode = new TreeNode("/");
-            _patchTreeView.Nodes.Add(rootNode);
-
-            mapNode(xElement, rootNode);
+            MapTreeView(_sourceXml.Root, _patchTreeView, _treeMenu);
         }
 
-        private void mapNode(XElement element, TreeNode parentTreeNode)
+        public static void MapTreeView(XElement root, TreeView patchTreeView, ContextMenuStrip treeMenu)
         {
-            var treeNode = new HighlightableTreeNode(element, _treeMenu);
+            var xElement = root;
+            var rootNode = new TreeNode("/");
+            patchTreeView.Nodes.Add(rootNode);
+
+            mapNode(xElement, rootNode, treeMenu);
+        }
+
+        public static void mapNode(XElement element, TreeNode parentTreeNode, ContextMenuStrip treeMenu)
+        {
+            var treeNode = new HighlightableTreeNode(element, treeMenu);
             
             foreach(var attr in element.Attributes())
             {
@@ -66,7 +71,7 @@ namespace PatchMaker.App
 
             foreach(var child in element.Elements())
             {
-                mapNode(child, treeNode);
+                mapNode(child, treeNode, treeMenu);
             }
         }
 

--- a/PatchMaker.App/TreeNodeExtensions.cs
+++ b/PatchMaker.App/TreeNodeExtensions.cs
@@ -93,7 +93,10 @@ namespace PatchMaker.App
                             }
                             query += clause;
                         }
-                        xPath += $"[{query}]";
+                        if (query.Length > 0)
+                        {
+                            xPath += $"[{query}]";
+                        }
                     }
                 }
 

--- a/PatchMaker.Tests/ExampleXml/Sitecore.ContentSearch.Solr.DefaultIndexConfiguration.config
+++ b/PatchMaker.Tests/ExampleXml/Sitecore.ContentSearch.Solr.DefaultIndexConfiguration.config
@@ -1,0 +1,637 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/" xmlns:search="http://www.sitecore.net/xmlconfig/search/">
+  <sitecore role:require="Standalone or ContentManagement or ContentDelivery" search:require="solr">
+    <contentSearch>
+      <!-- Configuration sections for indexes -->
+      <indexConfigurations>
+
+        <!-- If an index has no configuration specified, it will use the configuration below. The configuration is not merged if the index also has
+             configuration, it is either this configuration or the index configuration. -->
+        <defaultSolrIndexConfiguration type="Sitecore.ContentSearch.SolrProvider.SolrIndexConfiguration, Sitecore.ContentSearch.SolrProvider">
+          <!-- Should index Initialize() method be called as soon as the index is added or wait for an external trigger -->
+          <!-- For Solr Initialize() needs to be called after the IOC container has fired up -->
+          <initializeOnAdd>false</initializeOnAdd>
+
+          <!-- DEFAULT FIELD MAPPING 
+               This field map allows you to take full control over how your data is stored in the index. This can affect the way data is queried, performance of searching and how data is retrieved and casted to a proper type in the API. 
+            -->
+          <fieldMap type="Sitecore.ContentSearch.SolrProvider.SolrFieldMap, Sitecore.ContentSearch.SolrProvider">
+            <!-- This element must be first -->
+            <typeMatches hint="raw:AddTypeMatch">
+              <typeMatch typeName="guidCollection"              type="System.Collections.Generic.List`1[System.Guid]"     fieldNameFormat="{0}_sm"  multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="textCollection"              type="System.Collections.Generic.List`1[System.String]"   fieldNameFormat="{0}_txm" multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="stringCollection"            type="System.Collections.Generic.List`1[System.String]"   fieldNameFormat="{0}_sm"  multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="lowercaseStringCollection"   type="System.Collections.Generic.List`1[System.String]"   fieldNameFormat="{0}_lsm" multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="intCollection"               type="System.Collections.Generic.List`1[System.Int32]"    fieldNameFormat="{0}_im"  multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="guid"                        type="System.Guid"                                        fieldNameFormat="{0}_s"                                         settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="id"                          type="Sitecore.Data.ID, Sitecore.Kernel"                  fieldNameFormat="{0}_s"                                         settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="shortid"                     type="Sitecore.Data.ShortID, Sitecore.Kernel"             fieldNameFormat="{0}_s"                                         settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="lowercaseString"             type="System.String"                                      fieldNameFormat="{0}_ls"                                        settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="string"                      type="System.String"                                      fieldNameFormat="{0}_s"                                         settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="text"                        type="System.String"                                      fieldNameFormat="{0}_t"   cultureFormat="_{1}"                  settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="int"                         type="System.Int32"                                       fieldNameFormat="{0}_tl"                                        settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="bool"                        type="System.Boolean"                                     fieldNameFormat="{0}_b"                                         settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="datetime"                    type="System.DateTime"                                    fieldNameFormat="{0}_tdt" format="yyyy-MM-dd'T'HH:mm:ss.FFF'Z'" settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="long"                        type="System.Int64"                                       fieldNameFormat="{0}_tl"                                        settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="float"                       type="System.Single"                                      fieldNameFormat="{0}_tf"                                        settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="double"                      type="System.Double"                                      fieldNameFormat="{0}_td"                                        settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="stringArray"                 type="System.String[]"                                    fieldNameFormat="{0}_sm"  multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="intArray"                    type="System.Int32[]"                                     fieldNameFormat="{0}_im"  multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="datetimeArray"               type="System.DateTime[]"                                  fieldNameFormat="{0}_dtm" multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="datetimeCollection"          type="System.Collections.Generic.List`1[System.DateTime]" fieldNameFormat="{0}_dtm" multiValued="true"                    settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+              <typeMatch typeName="coordinate"                  type="Sitecore.ContentSearch.Data.Coordinate, Sitecore.ContentSearch.Data" fieldNameFormat="{0}_rpt"                      settingType="Sitecore.ContentSearch.SolrProvider.SolrSearchFieldConfiguration, Sitecore.ContentSearch.SolrProvider" />
+            </typeMatches>
+
+            <!-- This allows you to map a field name in Sitecore to the index and store it in the appropriate way -->
+            <!-- Add schema fields here to enable multi-language processing -->
+            <fieldNames hint="raw:AddFieldByFieldName">
+              <field fieldName="__created_by"         returnType="string" />
+              <field fieldName="__smallcreateddate"   returnType="datetime" format="yyyy-MM-dd'T'HH\:mm\:ss'Z'" />
+              <field fieldName="__smallupdateddate"   returnType="datetime" format="yyyy-MM-dd'T'HH\:mm\:ss'Z'" />
+              <field fieldName="__workflow_state"     returnType="string" />
+              <field fieldName="extension"            returnType="text" />
+              <field fieldName="title"                returnType="text" />
+              <field fieldName="type"                 returnType="text" />
+            </fieldNames>
+
+            <!-- FIELD TYPE MAPPING
+                 This allows you to map a field type in Sitecore to a type in the index.
+                 USAGE: When you add new field types to Sitecore, add the mappings here so they work through the Linq Layer 
+              -->
+            <fieldTypes hint="raw:AddFieldByFieldTypeName">
+              <fieldType fieldTypeName="checkbox"                                                                                                 returnType="bool"             />
+              <fieldType fieldTypeName="date|datetime"                                                                                            returnType="datetime"         />
+              <fieldType fieldTypeName="html|rich text|single-line text|multi-line text|text|memo|image|reference"                                returnType="text"             />
+              <fieldType fieldTypeName="word document"                                                                                            returnType="text"             />
+              <fieldType fieldTypeName="integer"                                                                                                  returnType="long"             />
+              <fieldType fieldTypeName="number"                                                                                                   returnType="float"            />
+              <fieldType fieldTypeName="icon|droplist|grouped droplist"                                                                           returnType="string"           />
+              <fieldType fieldTypeName="checklist|multilist|treelist|tree list|treelistex|tree list|multilist with search|treelist with search"   returnType="stringCollection" />
+              <fieldType fieldTypeName="name lookup value list|name value list"                                                                   returnType="stringCollection" />
+              <fieldType fieldTypeName="droplink|droptree|grouped droplink|tree"                                                                  returnType="stringCollection" />
+            </fieldTypes>
+          </fieldMap>
+
+          <documentOptions type="Sitecore.ContentSearch.SolrProvider.SolrDocumentBuilderOptions, Sitecore.ContentSearch.SolrProvider">
+            <!-- This flag will index all fields by default. This allows new fields in your templates to automatically be included into the index.
+               You have two choices : 
+               
+               1) Set this to true and place all the fields you would like to remove in the 'ExcludeField' list below.
+               2) Set to false and place all fields you would like to be indexed in the 'IncludeField' list below.
+            -->
+            <indexAllFields>true</indexAllFields>
+
+            <!-- GLOBALLY EXCLUDE TEMPLATES FROM BEING INDEXED
+                 This setting allows you to exclude items that are based on specific templates from the index.
+                 Template inheritance will be checked if checkTemplateInheritance is enabled.
+            -->
+            <exclude hint="list:AddExcludedTemplate">
+              <BucketFolderTemplateId>{ADB6CA4F-03EF-4F47-B9AC-9CE2BA53FF97}</BucketFolderTemplateId>
+            </exclude>
+
+            <!-- GLOBALLY INCLUDE TEMPLATES IN INDEX
+                 This setting allows you to only include items that are based on specific templates in the index. Template inheritance will be
+                 checked if checkTemplateInheritance is enabled.
+                 When you enable this setting, all the items that are based on other templates are excluded, regardless of whether the template
+                 is specified in the ExcludeTemplate list or not.
+            -->
+            <!--
+            <include hint="list:AddIncludedTemplate">
+              <StandardTemplate>{1930BBEB-7805-471A-A3BE-4858AC7CF696}</StandardTemplate>
+              <TemplateField>{455A3E98-A627-4B40-8035-E683A0331AC7}</TemplateField>
+            </include>-->
+
+            <!-- This flag will enable checking template inheritance / base templates when specifying templates to include
+                 or exclude from the index. This eliminates the need to explicitly specify all templates to include or
+                 exclude, but may affect performance.
+            -->
+            <checkTemplateInheritance>true</checkTemplateInheritance>
+
+            <!-- GLOBALLY INCLUDE FIELDS IN INDEX
+               This setting allows you to specify which fields to include in the index when the indexAllFields setting is set to false.
+            -->
+            <!--<include hint="list:AddIncludedField">
+            <fieldId>{8CDC337E-A112-42FB-BBB4-4143751E123F}</fieldId>
+            </include>-->
+
+            <!-- GLOBALLY EXCLUDE FIELDS FROM BEING INDEXED
+               This setting allows you to exclude fields from the index when the indexAllFields setting is set to true.
+            -->
+            <exclude hint="list:AddExcludedField">
+              <__Created>{25BED78C-4957-4165-998A-CA1B52F67497}</__Created>
+              <__DefaultWorkflow>{CA9B9F52-4FB0-4F87-A79F-24DEA62CDA65}</__DefaultWorkflow>
+              <__Lock>{001DD393-96C5-490B-924A-B0F25CD9EFD8}</__Lock>
+              <__LongDescription>{577F1689-7DE4-4AD2-A15F-7FDC1759285F}</__LongDescription>
+              <__Originator>{F6D8A61C-2F84-4401-BD24-52D2068172BC}</__Originator>
+              <__Owner>{52807595-0F8F-4B20-8D2A-CB71D28C6103}</__Owner>
+              <__ReadOnly>{9C6106EA-7A5A-48E2-8CAD-F0F693B1E2D4}</__ReadOnly>
+              <__Renderings>{F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}</__Renderings>
+              <__Final_Renderings>{04BF00DB-F5FB-41F7-8AB7-22408372A981}</__Final_Renderings>
+              <__Revision>{8CDC337E-A112-42FB-BBB4-4143751E123F}</__Revision>
+              <__Security>{DEC8D2D5-E3CF-48B6-A653-8E69E2716641}</__Security>
+              <__ShortDescription>{9541E67D-CE8C-4225-803D-33F7F29F09EF}</__ShortDescription>
+              <__SortOrder>{BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}</__SortOrder>
+              <__Source>{1B86697D-60CA-4D80-83FB-7555A2E6CE1C}</__Source>
+              <__SourceItem>{19B597D3-2EDD-4AE2-AEFE-4A94C7F10E31}</__SourceItem>
+              <__Updated>{D9CF14B1-FA16-4BA6-9288-E8A174D4D522}</__Updated>
+              <__UpdatedBy>{BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}</__UpdatedBy>
+              <__ValidFrom>{C8F93AFE-BFD4-4E8F-9C61-152559854661}</__ValidFrom>
+              <__Workflow>{A4F985D9-98B3-4B52-AAAF-4344F6E747C6}</__Workflow>
+              <ArchiveDate>{56C15C6D-FD5A-40CA-BB37-64CEEC6A9BD5}</ArchiveDate>
+              <ArchiveVersionDate>{1D99005E-65CA-45CA-9D9A-FD7016E23F1E}</ArchiveVersionDate>
+              <Boost>{93D1B217-B8F4-462E-BABF-68298C9CE667}</Boost>
+              <BucketParentReference>{9DAFCA1D-D618-4616-86B8-A8ACD6B28A63}</BucketParentReference>
+              <Cacheable>{3D08DB46-2267-41B0-BC52-BE69FD618633}</Cacheable>
+              <ContextMenu>{D3AE7222-425D-4B77-95D8-EE33AC2B6730}</ContextMenu>
+              <Controller>{4C9312A5-2E4E-42F8-AB6F-B8DB8B82BF22}</Controller>
+              <ControllerAction>{9FB734CC-8952-4072-A2D4-40F890E16F56}</ControllerAction>
+              <DefaultBucketQuery>{AC51462C-8A8D-493B-9492-34D1F26F20F1}</DefaultBucketQuery>
+              <DefaultView>{3607F9C7-DDA3-43C3-9720-39A7A5B3A4C3}</DefaultView>
+              <Editor>{D85DB4EC-FF89-4F9C-9E7C-A9E0654797FC}</Editor>
+              <Editors>{A0CB3965-8884-4C7A-8815-B6B2E5CED162}</Editors>
+              <EnabledViews>{F2DB8BA1-E477-41F5-8EF5-22EEFA8D2F6E}</EnabledViews>
+              <Facets>{21F74F6E-42D4-42A2-A4B4-4CEFBCFBD2BB}</Facets>
+              <HelpLink>{56776EDF-261C-4ABC-9FE7-70C618795239}</HelpLink>
+              <HideVersion>{B8F42732-9CB8-478D-AE95-07E25345FB0F}</HideVersion>
+              <Icon>{06D5295C-ED2F-4A54-9BF2-26228D113318}</Icon>
+              <Masters>{1172F251-DAD4-4EFB-A329-0C63500E4F1E}</Masters>
+              <NeverPublish>{9135200A-5626-4DD8-AB9D-D665B8C11748}</NeverPublish>
+              <PersistentFilter>{C7815F60-96E1-40CB-BB06-B5F833F73B61}</PersistentFilter>
+              <Preview>{41C6CC0E-389F-4D51-9990-FE35417B6666}</Preview>
+              <Publish>{86FE4F77-4D9A-4EC3-9ED9-263D03BD1965}</Publish>
+              <ReminderDate>{ABE5D54C-59D7-41E6-8D3F-C1A3E4EC9B9E}</ReminderDate>
+              <ReminderText>{BB6C8540-118E-4C49-9157-830576D7345A}</ReminderText>
+              <Renderers>{B03569B1-1534-43F2-8C83-BD064B7D782C}</Renderers>
+              <Ribbon>{0C894AAB-962B-4A84-B923-CB24B05E60D2}</Ribbon>
+              <Skin>{079AFCFE-8ACA-4863-BDA7-07893541E2F5}</Skin>
+              <Style>{A791F095-2521-4B4D-BEF9-21DDA221F608}</Style>
+              <SubItemSorting>{6FD695E7-7F6D-4CA5-8B49-A829E5950AE9}</SubItemSorting>
+              <SuppressedValidationRules>{F47C0D78-61F9-479C-96DF-1159727D32C6}</SuppressedValidationRules>
+              <UnPublish>{7EAD6FD6-6CF1-4ACA-AC6B-B200E7BAFE88}</UnPublish>
+              <UserAgent>{4E678FC0-8D35-4AB7-BB49-156F33C8B955}</UserAgent>
+              <ValidTo>{4C346442-E859-4EFD-89B2-44AEDF467D21}</ValidTo>
+              <VaryByData>{8B6D532B-6128-4486-A044-CA06D90948BA}</VaryByData>
+              <VaryByDevice>{C98CF969-BA71-42DA-833D-B3FC1368BA27}</VaryByDevice>
+              <VaryByLogin>{8D9232B0-613F-440B-A2FA-DCDD80FBD33E}</VaryByLogin>
+              <VaryByParam>{3AD2506A-DC39-4B1E-959F-9D524ADDBF50}</VaryByParam>
+              <VaryByQueryString>{1084D3D2-0457-456A-ABBC-EB4CC0966072}</VaryByQueryString>
+              <VaryByUser>{0E54A8DC-72AD-4372-A7C7-BB4773FAD44D}</VaryByUser>
+              <VaryByIndex>{F3E7E552-D7C8-469B-A150-69E4E14AB35C}</VaryByIndex>
+            </exclude>
+
+
+            <!-- GLOBALLY EXCLUDE FIELDS FROM FULL TEXT SEARCH
+               Provide a list of fields that should be excluded from full text search.
+            -->
+            <exclude hint="list:AddExcludedFieldFromFullTextSearch">
+              <__Created>{25BED78C-4957-4165-998A-CA1B52F67497}</__Created>
+              <__DefaultWorkflow>{CA9B9F52-4FB0-4F87-A79F-24DEA62CDA65}</__DefaultWorkflow>
+              <__Lock>{001DD393-96C5-490B-924A-B0F25CD9EFD8}</__Lock>
+              <__LongDescription>{577F1689-7DE4-4AD2-A15F-7FDC1759285F}</__LongDescription>
+              <__Originator>{F6D8A61C-2F84-4401-BD24-52D2068172BC}</__Originator>
+              <__Owner>{52807595-0F8F-4B20-8D2A-CB71D28C6103}</__Owner>
+              <__ReadOnly>{9C6106EA-7A5A-48E2-8CAD-F0F693B1E2D4}</__ReadOnly>
+              <__Renderings>{F1A1FE9E-A60C-4DDB-A3A0-BB5B29FE732E}</__Renderings>
+              <__Final_Renderings>{04BF00DB-F5FB-41F7-8AB7-22408372A981}</__Final_Renderings>
+              <__Revision>{8CDC337E-A112-42FB-BBB4-4143751E123F}</__Revision>
+              <__Security>{DEC8D2D5-E3CF-48B6-A653-8E69E2716641}</__Security>
+              <__ShortDescription>{9541E67D-CE8C-4225-803D-33F7F29F09EF}</__ShortDescription>
+              <__SortOrder>{BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}</__SortOrder>
+              <__Source>{1B86697D-60CA-4D80-83FB-7555A2E6CE1C}</__Source>
+              <__SourceItem>{19B597D3-2EDD-4AE2-AEFE-4A94C7F10E31}</__SourceItem>
+              <__Updated>{D9CF14B1-FA16-4BA6-9288-E8A174D4D522}</__Updated>
+              <__UpdatedBy>{BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}</__UpdatedBy>
+              <__ValidFrom>{C8F93AFE-BFD4-4E8F-9C61-152559854661}</__ValidFrom>
+              <__Workflow>{A4F985D9-98B3-4B52-AAAF-4344F6E747C6}</__Workflow>
+              <ArchiveDate>{56C15C6D-FD5A-40CA-BB37-64CEEC6A9BD5}</ArchiveDate>
+              <ArchiveVersionDate>{1D99005E-65CA-45CA-9D9A-FD7016E23F1E}</ArchiveVersionDate>
+              <Boost>{93D1B217-B8F4-462E-BABF-68298C9CE667}</Boost>
+              <BucketParentReference>{9DAFCA1D-D618-4616-86B8-A8ACD6B28A63}</BucketParentReference>
+              <Cacheable>{3D08DB46-2267-41B0-BC52-BE69FD618633}</Cacheable>
+              <ContextMenu>{D3AE7222-425D-4B77-95D8-EE33AC2B6730}</ContextMenu>
+              <Controller>{4C9312A5-2E4E-42F8-AB6F-B8DB8B82BF22}</Controller>
+              <ControllerAction>{9FB734CC-8952-4072-A2D4-40F890E16F56}</ControllerAction>
+              <DefaultBucketQuery>{AC51462C-8A8D-493B-9492-34D1F26F20F1}</DefaultBucketQuery>
+              <DefaultView>{3607F9C7-DDA3-43C3-9720-39A7A5B3A4C3}</DefaultView>
+              <Editor>{D85DB4EC-FF89-4F9C-9E7C-A9E0654797FC}</Editor>
+              <Editors>{A0CB3965-8884-4C7A-8815-B6B2E5CED162}</Editors>
+              <EnabledViews>{F2DB8BA1-E477-41F5-8EF5-22EEFA8D2F6E}</EnabledViews>
+              <Facets>{21F74F6E-42D4-42A2-A4B4-4CEFBCFBD2BB}</Facets>
+              <HelpLink>{56776EDF-261C-4ABC-9FE7-70C618795239}</HelpLink>
+              <HideVersion>{B8F42732-9CB8-478D-AE95-07E25345FB0F}</HideVersion>
+              <Icon>{06D5295C-ED2F-4A54-9BF2-26228D113318}</Icon>
+              <Masters>{1172F251-DAD4-4EFB-A329-0C63500E4F1E}</Masters>
+              <NeverPublish>{9135200A-5626-4DD8-AB9D-D665B8C11748}</NeverPublish>
+              <PersistentFilter>{C7815F60-96E1-40CB-BB06-B5F833F73B61}</PersistentFilter>
+              <Preview>{41C6CC0E-389F-4D51-9990-FE35417B6666}</Preview>
+              <Publish>{86FE4F77-4D9A-4EC3-9ED9-263D03BD1965}</Publish>
+              <ReminderDate>{ABE5D54C-59D7-41E6-8D3F-C1A3E4EC9B9E}</ReminderDate>
+              <ReminderText>{BB6C8540-118E-4C49-9157-830576D7345A}</ReminderText>
+              <Renderers>{B03569B1-1534-43F2-8C83-BD064B7D782C}</Renderers>
+              <Ribbon>{0C894AAB-962B-4A84-B923-CB24B05E60D2}</Ribbon>
+              <Skin>{079AFCFE-8ACA-4863-BDA7-07893541E2F5}</Skin>
+              <Style>{A791F095-2521-4B4D-BEF9-21DDA221F608}</Style>
+              <SubItemSorting>{6FD695E7-7F6D-4CA5-8B49-A829E5950AE9}</SubItemSorting>
+              <SuppressedValidationRules>{F47C0D78-61F9-479C-96DF-1159727D32C6}</SuppressedValidationRules>
+              <UnPublish>{7EAD6FD6-6CF1-4ACA-AC6B-B200E7BAFE88}</UnPublish>
+              <UserAgent>{4E678FC0-8D35-4AB7-BB49-156F33C8B955}</UserAgent>
+              <ValidTo>{4C346442-E859-4EFD-89B2-44AEDF467D21}</ValidTo>
+              <VaryByData>{8B6D532B-6128-4486-A044-CA06D90948BA}</VaryByData>
+              <VaryByDevice>{C98CF969-BA71-42DA-833D-B3FC1368BA27}</VaryByDevice>
+              <VaryByLogin>{8D9232B0-613F-440B-A2FA-DCDD80FBD33E}</VaryByLogin>
+              <VaryByParam>{3AD2506A-DC39-4B1E-959F-9D524ADDBF50}</VaryByParam>
+              <VaryByQueryString>{1084D3D2-0457-456A-ABBC-EB4CC0966072}</VaryByQueryString>
+              <VaryByUser>{0E54A8DC-72AD-4372-A7C7-BB4773FAD44D}</VaryByUser>
+              <VaryByIndex>{F3E7E552-D7C8-469B-A150-69E4E14AB35C}</VaryByIndex>
+            </exclude>
+
+            <!-- REMOVE INBUILT SITECORE FIELDS
+               This allows you to store a field in different ways in the index. You may want to store a field as Analyzed and Not Analyze
+            -->
+            <fields hint="raw:AddExcludedSpecialField">
+              <remove type="both">AllTemplates</remove>
+              <remove type="both">Created</remove>
+              <remove type="both">Editor</remove>
+              <remove type="both">Hidden</remove>
+              <remove type="both">Icon</remove>
+              <remove type="both">Links</remove>
+              <remove type="both">Updated</remove>
+            </fields>
+
+            <!-- COMPUTED INDEX FIELDS 
+               This setting allows you to add fields to the index that contain values that are computed for the item that is being indexed.
+               You can specify the storageType and indextype for each computed index field in the <fieldMap><fieldNames> section.
+            -->
+            <fields hint="raw:AddComputedIndexField">
+              <field fieldName="__smallcreateddate"             returnType="string"          >Sitecore.ContentSearch.ComputedFields.CreatedDate,Sitecore.ContentSearch</field>
+              <field fieldName="__smallupdateddate"             returnType="string"          >Sitecore.ContentSearch.ComputedFields.UpdatedDate,Sitecore.ContentSearch</field>
+              <field fieldName="_content"                       returnType="string"     type="Sitecore.ContentSearch.ComputedFields.MediaItemContentExtractor,Sitecore.ContentSearch">
+                <defaultMediaExtractor ref="contentSearch/indexConfigurations/contentExtraction/defaultMediaExtractor"/>
+                <mediaIndexing ref="contentSearch/indexConfigurations/defaultSolrIndexConfiguration/mediaIndexing"/>
+              </field>
+              <field fieldName="calculateddimension"            returnType="stringCollection">Sitecore.ContentSearch.ComputedFields.CalculatedDimension,Sitecore.ContentSearch</field>
+              <field fieldName="culture"                        returnType="string"          >Sitecore.ContentSearch.ComputedFields.Culture,Sitecore.ContentSearch</field>
+              <field fieldName="haschildren"                    returnType="bool"            >Sitecore.ContentSearch.ComputedFields.HasChildren,Sitecore.ContentSearch</field>
+              <field fieldName="istemplate"                     returnType="bool"            >Sitecore.ContentSearch.ComputedFields.IsTemplate,Sitecore.ContentSearch</field>
+              <field fieldName="lock"                           returnType="bool"            >Sitecore.ContentSearch.ComputedFields.IsLocked,Sitecore.ContentSearch</field>
+              <field fieldName="parsedcreatedby"                returnType="string"          >Sitecore.ContentSearch.ComputedFields.ParsedCreatedBy,Sitecore.ContentSearch</field>
+              <field fieldName="parsedupdatedby"                returnType="string"          >Sitecore.ContentSearch.ComputedFields.ParsedUpdatedBy,Sitecore.ContentSearch</field>
+              <field fieldName="parsedlanguage"                 returnType="string"          >Sitecore.ContentSearch.ComputedFields.ParsedLanguage,Sitecore.ContentSearch</field>
+              <field fieldName="site"                           returnType="stringCollection">Sitecore.ContentSearch.ComputedFields.Site,Sitecore.ContentSearch</field>
+              <field fieldName="sizerange"                      returnType="string"          >Sitecore.ContentSearch.ComputedFields.FileSizeGrouping,Sitecore.ContentSearch</field>
+              <field fieldName="isbucket_text"                  returnType="string"          >Sitecore.ContentSearch.ComputedFields.IsBucket,Sitecore.ContentSearch</field>
+              <field fieldName="__lock"                         returnType="string"          >Sitecore.ContentSearch.ComputedFields.ParsedLockOwner,Sitecore.ContentSearch</field>
+              <field fieldName="ispointofinterest"              returnType="bool"            >Sitecore.ContentSearch.ComputedFields.IsPointOfInterest, Sitecore.ContentSearch</field>
+              <field fieldName="coordinate"                     returnType="coordinate"      >Sitecore.ContentSearch.SolrProvider.ComputedFields.Coordinate, Sitecore.ContentSearch.SolrProvider</field>
+              <!-- Disabled for speed of indexing. Enable if you would like to query by the fields below -->
+              <!--<field fieldName="_isclone"                   returnType="bool"             >Sitecore.ContentSearch.ComputedFields.IsClone,Sitecore.ContentSearch</field>-->
+              <!--<field fieldName="_links"                     returnType="string"           >Sitecore.ContentSearch.ComputedFields.ItemLinks, Sitecore.ContentSearch</field>-->
+              <!--<field fieldName="_templates"                 returnType="string"      type="Sitecore.ContentSearch.ComputedFields.AllTemplates, Sitecore.ContentSearch" deep="true" includeStandardTemplate="false" />-->
+              <!--<field fieldName="hasclones"                  returnType="bool"             >Sitecore.ContentSearch.ComputedFields.HasClones,Sitecore.ContentSearch</field>-->
+              <!--<field fieldName="haspublishingrestrictions"  returnType="bool"             >Sitecore.ContentSearch.ComputedFields.HasPublishingRestrictions,Sitecore.ContentSearch</field>-->
+              <!--<field fieldName="isinworkflow"               returnType="bool"             >Sitecore.ContentSearch.ComputedFields.IsItemInWorkflow,Sitecore.ContentSearch</field>-->
+              <field fieldName="_readaccess">Sitecore.ContentSearch.ComputedFields.ReadAccess, Sitecore.ContentSearch</field>
+              <!-- The following computed fields must always be enabled for the Solr provider. -->
+              <field fieldName="__solr_norm_field_name"         returnType="string"          >Sitecore.ContentSearch.SolrProvider.FieldNames.TypeResolving.Index.ComputedFields.NormalizedTemplateFieldName,Sitecore.ContentSearch.SolrProvider</field>
+              <field fieldName="__solr_field_type"              returnType="string"          >Sitecore.ContentSearch.SolrProvider.FieldNames.TypeResolving.Index.ComputedFields.TemplateFieldType,Sitecore.ContentSearch.SolrProvider</field>
+            </fields>
+          </documentOptions>
+
+          <!-- MEDIA ITEM CONTENT EXTRACTOR FILE MAPPING 
+               This map allows you to specify the extensions and mimetypes that we will pass through to the IFilters on your machine so they can be indexed.
+               We also allow you to include all files or exclude all files and leave it to the IFilters to control what is and is not indexed.
+          -->
+          <mediaIndexing hint="skip">
+            <mimeTypes>
+              <excludes>
+                <mimeType>*</mimeType>
+              </excludes>
+              <includes>
+                <mimeType>application/pdf</mimeType>
+                <mimeType type="Sitecore.ContentSearch.ComputedFields.MediaItemHtmlTextExtractor, Sitecore.ContentSearch">text/html</mimeType>
+                <mimeType>text/plain</mimeType>
+              </includes>
+            </mimeTypes>
+            <extensions>
+              <excludes>
+                <extension>*</extension>
+              </excludes>
+              <includes>
+                <extension>rtf</extension>
+                <extension>odt</extension>
+                <extension>doc</extension>
+                <extension>dot</extension>
+                <extension>docx</extension>
+                <extension>dotx</extension>
+                <extension>docm</extension>
+                <extension>dotm</extension>
+                <extension>xls</extension>
+                <extension>xlt</extension>
+                <extension>xla</extension>
+                <extension>xlsx</extension>
+                <extension>xlsm</extension>
+                <extension>xltm</extension>
+                <extension>xlam</extension>
+                <extension>xlsb</extension>
+                <extension>ppt</extension>
+                <extension>pot</extension>
+                <extension>pps</extension>
+                <extension>ppa</extension>
+                <extension>pptx</extension>
+                <extension>potx</extension>
+                <extension>ppsx</extension>
+                <extension>ppam</extension>
+                <extension>pptm</extension>
+                <extension>potm</extension>
+                <extension>ppsm</extension>
+              </includes>
+            </extensions>
+          </mediaIndexing>
+
+          <!-- VIRTUAL FIELDS
+               Virtual fields can be used to translate a field query into a different query.
+            -->
+          <virtualFields type="Sitecore.ContentSearch.VirtualFieldProcessorMap, Sitecore.ContentSearch">
+            <processors hint="raw:AddFromConfiguration">
+              <add fieldName="daterange" type="Sitecore.ContentSearch.VirtualFields.DateRangeFieldProcessor, Sitecore.ContentSearch" />
+              <add fieldName="_lastestversion" type="Sitecore.ContentSearch.VirtualFields.LatestVersionFieldProcessor, Sitecore.ContentSearch" />
+              <add fieldName="updateddaterange" type="Sitecore.ContentSearch.VirtualFields.UpdatedDateRangeFieldProcessor, Sitecore.ContentSearch" />
+              <add fieldName="_url" type="Sitecore.ContentSearch.VirtualFields.UniqueIdFieldProcessor, Sitecore.ContentSearch" />
+              <add fieldName="_fullpath" type="Sitecore.ContentSearch.SolrProvider.VirtualFields.FullPathFieldProcessor, Sitecore.ContentSearch.SolrProvider" />
+              <add fieldName="parsedcreatedby_s" type="Sitecore.ContentSearch.VirtualFields.CreatedByFieldProcessor, Sitecore.ContentSearch" />
+            </processors>
+          </virtualFields>
+
+          <!-- SITECORE FIELDTYPE MAP
+               This maps a field type by name to a Strongly Typed Implementation of the field type e.g. html maps to HTMLField
+            -->
+          <fieldReaders type="Sitecore.ContentSearch.FieldReaders.FieldReaderMap, Sitecore.ContentSearch">
+            <param desc="id">defaultFieldReaderMap</param>
+            <mapFieldByTypeName hint="raw:AddFieldReaderByFieldTypeName">
+              <fieldReader fieldTypeName="checkbox"                                             fieldReaderType="Sitecore.ContentSearch.FieldReaders.CheckboxFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="date|datetime"                                        fieldReaderType="Sitecore.ContentSearch.FieldReaders.DateFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="image"                                                fieldReaderType="Sitecore.ContentSearch.FieldReaders.ImageFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="single-line text|multi-line text|text|memo"           fieldReaderType="Sitecore.ContentSearch.FieldReaders.DefaultFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="integer"                                              fieldReaderType="Sitecore.ContentSearch.FieldReaders.NumericFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="number"                                               fieldReaderType="Sitecore.ContentSearch.FieldReaders.PrecisionNumericFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="html|rich text"                                       fieldReaderType="Sitecore.ContentSearch.FieldReaders.RichTextFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="multilist with search|treelist with search"           fieldReaderType="Sitecore.ContentSearch.FieldReaders.DelimitedListFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="checklist|multilist|treelist|treelistex|tree list"    fieldReaderType="Sitecore.ContentSearch.FieldReaders.MultiListFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="icon|droplist|grouped droplist"                       fieldReaderType="Sitecore.ContentSearch.FieldReaders.DefaultFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="name lookup value list|name value list"               fieldReaderType="Sitecore.ContentSearch.FieldReaders.NameValueListFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="droplink|droptree|grouped droplink|tree|reference"    fieldReaderType="Sitecore.ContentSearch.FieldReaders.LookupFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="attachment|frame|rules|tracking|thumbnail"            fieldReaderType="Sitecore.ContentSearch.FieldReaders.NullFieldReader, Sitecore.ContentSearch" />
+              <fieldReader fieldTypeName="file|security|server file|template field source|link" fieldReaderType="Sitecore.ContentSearch.FieldReaders.NullFieldReader, Sitecore.ContentSearch" />
+            </mapFieldByTypeName>
+          </fieldReaders>
+
+          <!-- INDEX FIELD STORAGE MAPPER 
+               Maintains a collection of all the possible Convertors for the provider.
+            -->
+          <indexFieldStorageValueFormatter type="Sitecore.ContentSearch.SolrProvider.Converters.SolrIndexFieldStorageValueFormatter, Sitecore.ContentSearch.SolrProvider">
+            <converters hint="raw:AddConverter">
+              <converter handlesType="System.Guid"                                                          typeConverter="Sitecore.ContentSearch.Converters.IndexFieldGuidValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.Data.ID, Sitecore.Kernel"                                    typeConverter="Sitecore.ContentSearch.Converters.IndexFieldIDValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.Data.ShortID, Sitecore.Kernel"                               typeConverter="Sitecore.ContentSearch.Converters.IndexFieldShortIDValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="System.DateTime"                                                      typeConverter="Sitecore.ContentSearch.Converters.IndexFieldUTCDateTimeValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="System.DateTimeOffset"                                                typeConverter="Sitecore.ContentSearch.Converters.IndexFieldDateTimeOffsetValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="System.TimeSpan"                                                      typeConverter="Sitecore.ContentSearch.Converters.IndexFieldTimeSpanValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.ContentSearch.SitecoreItemId, Sitecore.ContentSearch"        typeConverter="Sitecore.ContentSearch.Converters.IndexFieldSitecoreItemIDValueConvertor, Sitecore.ContentSearch">
+                <param type="Sitecore.ContentSearch.Converters.IndexFieldIDValueConverter, Sitecore.ContentSearch"/>
+              </converter>
+              <converter handlesType="Sitecore.ContentSearch.SitecoreItemUniqueId, Sitecore.ContentSearch"  typeConverter="Sitecore.ContentSearch.SolrProvider.Converters.SolrIndexFieldSitecoreItemUniqueIDValueConverter, Sitecore.ContentSearch.SolrProvider">
+                <param type="Sitecore.ContentSearch.Converters.IndexFieldItemUriValueConverter, Sitecore.ContentSearch"/>
+              </converter>
+              <converter handlesType="Sitecore.Data.ItemUri, Sitecore.Kernel"                               typeConverter="Sitecore.ContentSearch.Converters.IndexFieldItemUriValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.Globalization.Language, Sitecore.Kernel"                     typeConverter="Sitecore.ContentSearch.Converters.IndexFieldLanguageValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="System.Globalization.CultureInfo"                                     typeConverter="Sitecore.ContentSearch.Converters.IndexFieldCultureInfoValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.Data.Version, Sitecore.Kernel"                               typeConverter="Sitecore.ContentSearch.Converters.IndexFieldVersionValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.Data.Database, Sitecore.Kernel"                              typeConverter="Sitecore.ContentSearch.Converters.IndexFieldDatabaseValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.ContentSearch.IIndexableId, Sitecore.ContentSearch"          typeConverter="Sitecore.ContentSearch.Converters.IndexableIdConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.ContentSearch.IIndexableUniqueId, Sitecore.ContentSearch"    typeConverter="Sitecore.ContentSearch.Converters.IndexableUniqueIdConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.ContentSearch.Data.Coordinate, Sitecore.ContentSearch.Data"  typeConverter="Sitecore.ContentSearch.Converters.IndexFieldCoordinateValueConverter, Sitecore.ContentSearch" />
+              <converter handlesType="Sitecore.ContentSearch.Linq.Highlighting.Highlights, Sitecore.ContentSearch.Linq"  typeConverter="Sitecore.ContentSearch.Converters.IndexFieldHighlightsValueConverter, Sitecore.ContentSearch" />
+            </converters>
+          </indexFieldStorageValueFormatter>
+
+          <!-- INDEX PROPERTY TO DOCUMENT MAPPER
+               Maintains a collection of all the possible Convertors for the provider.
+            -->
+          <indexDocumentPropertyMapper type="Sitecore.ContentSearch.SolrProvider.Mapping.SolrDocumentPropertyMapper, Sitecore.ContentSearch.SolrProvider">
+            <!-- OBJECT FACTORY
+                 Constructs search result objects based on the type that is passed in .GetQueryable<T>() and the rules defined in this section.
+            -->
+            <objectFactory type="Sitecore.ContentSearch.DefaultDocumentMapperObjectFactory, Sitecore.ContentSearch">
+              <!-- OBJECT FACTORY RULES 
+
+                   Examples:
+
+                    <rules hint="list:AddRule">
+
+                      Rule that applies to items with template "Sample Item":
+
+                      <rule fieldName="template" comparison="Equal" value="{76036F5E-CBCE-46D1-AF0A-4143F9B557AA}" valueType="System.Guid, mscorlib"
+                            creationType="MySearchTypes.SampleItemResultItem, MySearchTypes"
+                            baseType="MySearchTypes.IMySearchResultItem, MySearchTypes"
+                            type="Sitecore.ContentSearch.DefaultDocumentMapperFactorySimpleRule, Sitecore.ContentSearch">
+                        <param desc="fieldName">$(fieldName)</param>
+                        <param desc="comparison">$(comparison)</param>
+                        <param desc="value">$(value)</param>
+                        <param desc="type">$(valueType)</param>
+                        <param desc="creationType">$(creationType)</param>
+                        <param desc="baseType">$(baseType)</param>
+                      </rule>
+
+                      Rule that applies to items with template "Sample Item" AND has the title "Sample Item":
+
+                      <rule type="Sitecore.ContentSearch.DefaultDocumentMapperFactoryRule, Sitecore.ContentSearch"
+                            creationType="MySearchTypes.SampleItemResultItem, MySearchTypes"
+                            baseType="MySearchTypes.IMySearchResultItem, MySearchTypes">
+                        <param desc="creationType">$(creationType)</param>
+                        <param desc="baseType">$(baseType)</param>
+                  
+                        <fieldComparisons hint="list:AddFieldComparison">
+
+                          <fieldComparison fieldName="template" comparison="Equal" value="{76036F5E-CBCE-46D1-AF0A-4143F9B557AA}" valueType="System.Guid, mscorlib" type="Sitecore.ContentSearch.DefaultDocumentMapperFactoryRuleFieldComparison, Sitecore.ContentSearch">
+                            <param desc="fieldName">$(fieldName)</param>
+                            <param desc="comparison">$(comparison)</param>
+                            <param desc="value">$(value)</param>
+                            <param desc="type">$(valueType)</param>
+                          </fieldComparison>
+
+                          <fieldComparison fieldName="title" comparison="Equal" value="Sample Item" valueType="System.String, mscorlib" type="Sitecore.ContentSearch.DefaultDocumentMapperFactoryRuleFieldComparison, Sitecore.ContentSearch">
+                            <param desc="fieldName">$(fieldName)</param>
+                            <param desc="comparison">$(comparison)</param>
+                            <param desc="value">$(value)</param>
+                            <param desc="type">$(valueType)</param>
+                          </fieldComparison>
+
+                        </fieldComparisons>
+                      </rule>
+
+                    </rules>
+              -->
+            </objectFactory>
+          </indexDocumentPropertyMapper>
+
+          <!-- DOCUMENT BUILDER
+               Allows you to override the document builder. The document builder class processes all the fields in the Sitecore items and prepares
+               the data for storage in the index.
+               You can override the document builder to modify how the data is prepared, and to apply any additional logic that you may require.
+          -->
+          <documentBuilderType>Sitecore.ContentSearch.SolrProvider.SolrDocumentBuilder, Sitecore.ContentSearch.SolrProvider</documentBuilderType>
+
+          <defaultSearchSecurityOption ref="contentSearch/indexConfigurations/defaultSearchSecurityOption" />
+
+          <enableReadAccessIndexing ref="contentSearch/indexConfigurations/enableReadAccessIndexing" />
+
+          <searchOptions type="Sitecore.ContentSearch.Linq.Solr.SolrSearchOptions, Sitecore.ContentSearch.Linq.Solr" singleInstance="true">
+            <textQueryTranslatorStore type="Sitecore.ContentSearch.Linq.Solr.Parsing.ConfigBasedSolrTextQueryTranslatorStore, Sitecore.ContentSearch.Linq.Solr">
+              <param desc="factory" resolve="true" type="Sitecore.Abstractions.BaseFactory, Sitecore.Kernel" />
+              <queryTranslators hint="list:AddTranslator">
+                <queryTranslator key="default" type="Sitecore.ContentSearch.Linq.Solr.Parsing.EscapedSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="phrase" type="Sitecore.ContentSearch.Linq.Solr.Parsing.PhraseSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.equals" type="Sitecore.ContentSearch.Linq.Solr.Parsing.PhraseSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.starts_with" type="Sitecore.ContentSearch.Linq.Solr.Parsing.StartsWithTermSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.ends_with" type="Sitecore.ContentSearch.Linq.Solr.Parsing.EndsWithTermSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.contains" type="Sitecore.ContentSearch.Linq.Solr.Parsing.ContainsTermSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.matches.regex" type="Sitecore.ContentSearch.Linq.Solr.Parsing.RegExSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.matches.wildcard" type="Sitecore.ContentSearch.Linq.Solr.Parsing.WildcardSolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.like.fuzzy" type="Sitecore.ContentSearch.Linq.Solr.Parsing.FuzzySolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+                <queryTranslator key="cs.linq.like.proximity" type="Sitecore.ContentSearch.Linq.Solr.Parsing.ProximitySolrTextQueryTranslator, Sitecore.ContentSearch.Linq.Solr" />
+              </queryTranslators>
+            </textQueryTranslatorStore>
+          </searchOptions>
+
+          <highlightOptions type="Sitecore.ContentSearch.Linq.Solr.Highlighting.SolrHighlightOptions, Sitecore.ContentSearch.Linq.Solr" singleInstance="true" >
+            <parametersMapper type="Sitecore.ContentSearch.Linq.Solr.Highlighting.DefaultSolrHighlightParametersMapper, Sitecore.ContentSearch.Linq.Solr" />
+            <presetStore type="Sitecore.ContentSearch.Linq.Highlighting.ConfigurationBasedHighlightsPresetStore, Sitecore.ContentSearch.Linq">
+              <presets hint="list:AddPreset">
+                <!--preset id="example" type="Sitecore.ContentSearch.Linq.Highlighting.ConfigurationBasedHighlightsPresetStore+HighlightPreset, Sitecore.ContentSearch.Linq">
+                  <param desc="name">$(id)</param>
+                  <param desc="parameters" type="Sitecore.ContentSearch.Linq.Highlighting.HighlightParameters, Sitecore.ContentSearch.Linq">
+                    <preTag>((</preTag>
+                    <postTag>))</postTag>
+                    <maxSnippetsNumber>1</maxSnippetsNumber>
+                  </param>
+                </preset-->
+              </presets>
+            </presetStore>
+          </highlightOptions>
+
+        </defaultSolrIndexConfiguration>
+
+        <!-- HTTP WEB REQUEST FACTORY
+              Allows you to override the http web request factory. This factory class is responsible for creating IHttpWebRequest's.
+         -->
+        <solrHttpWebRequestFactory type="Sitecore.ContentSearch.SolrProvider.SolrNetIntegration.Requests.SolrHttpWebRequestAdaptingFactory, Sitecore.ContentSearch.SolrProvider">
+          <param type="Sitecore.ContentSearch.Remote.Http.CompositeHttpWebRequestFactory, Sitecore.ContentSearch">
+            <initializers hint="list:AddInitializer">
+              <basicAuthentication type="Sitecore.ContentSearch.SolrProvider.SolrNetIntegration.Requests.SolrHttpRequestInitializerFactory, Sitecore.ContentSearch.SolrProvider" factoryMethod="EnableBasicAuthentication" />
+              <serverCertificate type="Sitecore.ContentSearch.SolrProvider.SolrNetIntegration.Requests.SolrHttpRequestInitializerFactory, Sitecore.ContentSearch.SolrProvider" factoryMethod="EnableServerCertificateValidation" />
+              <clientCertificate type="Sitecore.ContentSearch.SolrProvider.SolrNetIntegration.Requests.SolrHttpRequestInitializerFactory, Sitecore.ContentSearch.SolrProvider" factoryMethod="EnableClientCertificateAuthentication" />
+            </initializers>
+          </param>
+        </solrHttpWebRequestFactory>
+
+        <solrRetryer type="Sitecore.ContentSearch.SolrProvider.Availability.Retryer.NoRetryRetryer, Sitecore.ContentSearch.SolrProvider" singleInstance="true" />
+
+        <!-- A factory to create a resolver used to resolve a sitecore item field type from a field name. -->
+        <itemFieldTypeResolverFactory type="Sitecore.ContentSearch.SolrProvider.FieldNames.TypeResolving.Index.SolrItemFieldTypeResolverFactory, Sitecore.ContentSearch.SolrProvider"/>
+
+      </indexConfigurations>
+    </contentSearch>
+    <services>
+      <!-- Enables healthchecks for Solr server -->
+      <configurator type= "Sitecore.ContentSearch.SolrProvider.DependencyInjection.ContentSearchServicesConfigurator, Sitecore.ContentSearch.SolrProvider"/>
+    </services>
+    <pipelines>
+      <initialize>
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.Loader.InitializeSolrProvider, Sitecore.ContentSearch.SolrProvider" patch:before="*[@type='Sitecore.Pipelines.Loader.InitializeScheduler, Sitecore.Kernel']"/>
+      </initialize>
+      <contentSearch.translateQuery>
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.TranslateQuery.ApplySolrTranslation, Sitecore.ContentSearch.SolrProvider" />
+      </contentSearch.translateQuery>
+      <!-- The 'contentSearch.formatQueryFieldValue' pipeline has been obsoleted. It will be removed in a future release. -->
+      <contentSearch.formatQueryFieldValue>
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.FormatQueryFieldValue.ApplyFieldMappingRule, Sitecore.ContentSearch.SolrProvider" />
+      </contentSearch.formatQueryFieldValue>
+      <contentSearch.PopulateSolrSchema>
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.PopulateSolrSchema.ResolveCoreNames, Sitecore.ContentSearch.SolrProvider" />
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.PopulateSolrSchema.PopulateFields, Sitecore.ContentSearch.SolrProvider">
+          <param type="Sitecore.ContentSearch.SolrProvider.Factories.DefaultPopulateHelperFactory" />
+        </processor>
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.PopulateSolrSchema.EnsureSchemaPopulated, Sitecore.ContentSearch.SolrProvider">
+          <maxNumberOfRetries>3</maxNumberOfRetries>
+          <waitTimeBetweenRetries>00:00:03</waitTimeBetweenRetries>
+        </processor>
+        <processor type="Sitecore.ContentSearch.SolrProvider.Pipelines.PopulateSolrSchema.ReInitializeIndex, Sitecore.ContentSearch.SolrProvider" />
+      </contentSearch.PopulateSolrSchema>
+    </pipelines>
+    <scheduling>
+      <agent type="Sitecore.ContentSearch.SolrProvider.Agents.IsSolrAliveAgent, Sitecore.ContentSearch.SolrProvider" method="Run" interval="00:10:00" />
+      <agent type="Sitecore.ContentSearch.SolrProvider.Agents.IndexingStateSwitcher, Sitecore.ContentSearch.SolrProvider" method="Run" interval="00:01:00" />
+    </scheduling>
+    <settings>
+      <!-- DEFAULT INDEX CONFIGURATION PATH 
+           This setting specifies an XPath expression that points to the default index configuration. The default configuration is used for
+           every index that does not have a specified configuration.
+      -->
+      <setting name="ContentSearch.DefaultIndexConfigurationPath" value="contentSearch/indexConfigurations/defaultSolrIndexConfiguration" />
+
+      <!--  CONNECTION TIMEOUT
+            The timeout interval for the Solr server connection in milliseconds.
+            A value of -1 (minus one) means that the default SolrNet timeout interval is used.
+            Default value: -1
+      -->
+      <setting name="ContentSearch.Solr.ConnectionTimeout" value="-1" />
+
+      <!-- SEND POST REQUESTS TO SOLR
+           This setting specified whether POST method is always used to communicate with SOLR. If value is false, GET can be used for some Solr commands.
+           The setting can be useful if you face issues related to URI length limitation.  
+           Default value: false
+      -->
+      <setting name="ContentSearch.Solr.SendPostRequests" value="false" />
+
+      <!--  BATCH MODE
+            Commits to the database in batches (to reduce trips to the database / server).
+      -->
+      <setting name="ContentSearch.Update.BatchModeEnabled" value="true" />
+
+      <!--  BATCH SIZE
+            The size of document batch before flushing to the database.
+      -->
+      <setting name="ContentSearch.Update.BatchSize" value="500" />
+
+      <!--  PARALLEL INDEX INITIALIZATION MAX THREAD LIMIT
+            This setting allows you to limit the number of threads used for requesting data from Solr needed for indexes initialization.
+            If the value is set to 0, there is no limit to the number of threads.
+            
+            Default value: 6
+      -->
+      <setting name="ContentSearch.Solr.ParallelIndexInitialization.MaxThreadLimit" value="6" />
+
+      <!--  MAX NUMBER OF FIELD TO PROJECT
+            This setting allows you to limit the number of fields requested by a search query.
+            If the limit is reached, all fields are retrieved. 
+            If the value is set to 0, search results will always contain all fields.
+            Default value: 15
+      -->
+      <setting name="ContentSearch.Solr.MaxNumberOfFieldsToProject" value="15" />
+
+      <!--  SUGGEST HANDLER
+        The name of suggest request handler as configured in solr -->
+      <setting name="ContentSearch.Solr.SuggestHandler" value="/suggest" />
+
+      <!--  SPELL CHECK HANDLER
+        The name of spell check request handler as configured in solr -->
+      <setting name="ContentSearch.Solr.SpellCheckHandler" value="/spell" />
+
+      <!--  ENABLE OPTIMIZE ON REBUILD
+            If enabled, the index optimization command runs when the rebuild is completed.            
+            Default vaue: false
+      -->
+      <setting name="ContentSearch.Solr.OptimizeOnRebuild.Enabled" value="false" />
+    </settings>
+  </sitecore>
+</configuration>

--- a/PatchMaker.Tests/IntegrationTests.cs
+++ b/PatchMaker.Tests/IntegrationTests.cs
@@ -32,7 +32,7 @@ namespace PatchMaker.Tests
 
              var patches = new BasePatch[] {
                 new PatchInsert("/sitecore/sites", ElementInsertPosition.After, "site[@name='website']", newSite),
-                new SetAttribute("/sitecore/mediaLibrary/mediaPrefixes/prefix[@value='~/media']", "value", "~/art"),
+                 new SetAttribute("/sitecore/mediaLibrary/mediaPrefixes/prefix[@value='~/media']", "value", "~/art"),
                 new PatchInstead("/sitecore", "sc.variable[@name='dataFolder']", newDataFolder),
                 new PatchDelete("/sitecore/tracking/untrackedPages/add[@path='/sitecore/default.aspx']")
             };

--- a/PatchMaker.Tests/PatchMaker.Tests.csproj
+++ b/PatchMaker.Tests/PatchMaker.Tests.csproj
@@ -47,6 +47,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
@@ -60,15 +61,21 @@
     <Compile Include="SetAttributeTests.cs" />
     <Compile Include="PatchGeneratorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TreeNodeExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ExampleXml\role-namespace.config" />
+    <None Include="ExampleXml\Sitecore.ContentSearch.Solr.DefaultIndexConfiguration.config" />
     <None Include="ExampleXml\v92-sitecore.config" />
     <None Include="packages.config" />
     <None Include="ExampleXml\Sitecore.config" />
     <None Include="ExampleXml\v92-runtime.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\PatchMaker.App\PatchMaker.App.csproj">
+      <Project>{B0004E7F-817E-4CD3-91FE-BD9404AAF770}</Project>
+      <Name>PatchMaker.App</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PatchMaker.Sitecore\PatchMaker.Sitecore.csproj">
       <Project>{654e7eea-b1b9-4efa-b262-762cdbc354bc}</Project>
       <Name>PatchMaker.Sitecore</Name>

--- a/PatchMaker.Tests/TreeNodeExtensionsTests.cs
+++ b/PatchMaker.Tests/TreeNodeExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PatchMaker.App;
+using System.Windows.Forms;
+using System.Xml.Linq;
+
+namespace PatchMaker.Tests
+{
+    
+    [TestClass]
+    public class TreeNodeExtensionsTests
+    {
+        [TestMethod]
+        public void TreeNodeExtensions_XpathForNamespacedNode_DoesNotIncludeEmptyIndexer()
+        {
+            var xml = XDocument.Load(@"..\..\ExampleXml\Sitecore.ContentSearch.Solr.DefaultIndexConfiguration.config");
+            var tree = new TreeView();
+
+            PatchProcessManager.MapTreeView(xml.Root, tree, null);
+
+            var node = tree.Nodes[0];
+
+            var xpath = TreeNodeExtensions.DefaultXPath(node);
+
+            // the xpath generation should never create
+            // "/root[]/node" when there are only namespaces to process
+            // that aren't relevant to the final expression
+            Assert.IsFalse(xpath.Contains("[]"));
+        }
+    }
+
+}

--- a/PatchMaker/Metadata.cs
+++ b/PatchMaker/Metadata.cs
@@ -4,8 +4,8 @@ namespace PatchMaker
 {
     public static class Metadata
     {
-        public const string AssemblyVersion = "1.5.1.0";
-        public const string AssemblyCopyright = "Copyright © Jeremy Davis 2020";
+        public const string AssemblyVersion = "1.5.2.0";
+        public const string AssemblyCopyright = "Copyright © Jeremy Davis 2020 - 2022";
         public const string AssemblyProduct = "PatchMaker";
     }
 


### PR DESCRIPTION
The issue in #45 was caused by generating invalid xpath if a node had namespaced attributes which were not relevant to the query. In that situation it would add `root[]/node` to the query - causing an error when trying to process the xpath. Added test to verify the issue, and a bugfix to resolve the test.