### PR TITLE
Bug/49 invalid xpath from sitecore tokens

### DIFF
--- a/PatchMaker.App/TreeNodeExtensions.cs
+++ b/PatchMaker.App/TreeNodeExtensions.cs
@@ -86,13 +86,24 @@ namespace PatchMaker.App
                                 continue;
                             }
 
-                            var clause = $"@{computeAppropriateName(xAttr, xElement)}='{xAttr.Value}'";
+                            var attrVal = xAttr.Value;
+                            var quoteChar = '\'';
+
+                            // if the attribute value we're testing for contains a single quote char,
+                            // make sure the surrounding xpath clause does not use single quotes itself
+                            if (attrVal.Contains("'"))
+                            {
+                                quoteChar = '"';
+                            }
+
+                            var clause = $"@{computeAppropriateName(xAttr, xElement)}={quoteChar}{attrVal}{quoteChar}";
                             if (query.Length > 0)
                             {
                                 query += " and ";
                             }
                             query += clause;
                         }
+
                         if (query.Length > 0)
                         {
                             xPath += $"[{query}]";

--- a/PatchMaker.Tests/PatchMaker.Tests.csproj
+++ b/PatchMaker.Tests/PatchMaker.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="PatchGeneratorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TreeNodeExtensionsTests.cs" />
+    <Compile Include="XElementExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ExampleXml\role-namespace.config" />

--- a/PatchMaker.Tests/TreeNodeExtensionsTests.cs
+++ b/PatchMaker.Tests/TreeNodeExtensionsTests.cs
@@ -7,7 +7,7 @@ using System.Xml.XPath;
 
 namespace PatchMaker.Tests
 {
-    
+
     [TestClass]
     public class TreeNodeExtensionsTests
     {

--- a/PatchMaker.Tests/TreeNodeExtensionsTests.cs
+++ b/PatchMaker.Tests/TreeNodeExtensionsTests.cs
@@ -25,6 +25,8 @@ namespace PatchMaker.Tests
 
             var elements = xml.Root.XPathSelectElements(xpath);
 
+            // Avoid creating xpath attribute checks where a clause containing
+            // single quotes is itself wrapped in single quotes
             Assert.IsNotNull(elements);
             Assert.AreEqual(1, elements.Count());
         }

--- a/PatchMaker.Tests/TreeNodeExtensionsTests.cs
+++ b/PatchMaker.Tests/TreeNodeExtensionsTests.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PatchMaker.App;
+using System.Linq;
 using System.Windows.Forms;
 using System.Xml.Linq;
+using System.Xml.XPath;
 
 namespace PatchMaker.Tests
 {
@@ -9,6 +11,24 @@ namespace PatchMaker.Tests
     [TestClass]
     public class TreeNodeExtensionsTests
     {
+        [TestMethod]
+        public void TreeNodeExtensions_GeneratePatchFromElementWithXpath_DoesNotFail()
+        {
+            var xml = XDocument.Parse(@"<root><e name=""1"" query=""/test[@a='b']""/></root>");
+            var tree = new TreeView();
+
+            PatchProcessManager.MapTreeView(xml.Root, tree, null);
+
+            var node = tree.Nodes[0].Nodes[0];
+
+            var xpath = TreeNodeExtensions.DefaultXPath(node);
+
+            var elements = xml.Root.XPathSelectElements(xpath);
+
+            Assert.IsNotNull(elements);
+            Assert.AreEqual(1, elements.Count());
+        }
+
         [TestMethod]
         public void TreeNodeExtensions_XpathForNamespacedNode_DoesNotIncludeEmptyIndexer()
         {

--- a/PatchMaker.Tests/XElementExtensionsTests.cs
+++ b/PatchMaker.Tests/XElementExtensionsTests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PatchMaker.Tests
+{
+    
+    [TestClass]
+    public class XElementExtensionsTests
+    {
+        [TestMethod]
+        public void XElementExtensions_WithoutNestedQuery_FirstPathSegmentIsCorrect()
+        {
+            var path = "/sitecore[@database='SqlServer']/events[@timingLevel='custom']/event[@name='item:saved']/handler[@type='Sitecore.ExperienceAnalytics.Client.Deployment.Events.SegmentDeployedEventHandler, Sitecore.ExperienceAnalytics.Client' and @method='OnItemSaved']/param[@type='Sitecore.ExperienceAnalytics.Client.Deployment.DeploySegmentDefinitionProcessor, Sitecore.ExperienceAnalytics.Client']";
+
+            var idx = path.LastPathSegmentIndex();
+            var parent = path.FirstPathSegment(idx);
+            var remainder = path.RemainingPathSegments(idx);
+
+            Assert.AreEqual("/sitecore[@database='SqlServer']/events[@timingLevel='custom']/event[@name='item:saved']/handler[@type='Sitecore.ExperienceAnalytics.Client.Deployment.Events.SegmentDeployedEventHandler, Sitecore.ExperienceAnalytics.Client' and @method='OnItemSaved']", parent);
+            Assert.AreEqual("param[@type='Sitecore.ExperienceAnalytics.Client.Deployment.DeploySegmentDefinitionProcessor, Sitecore.ExperienceAnalytics.Client']", remainder);
+        }
+
+        [TestMethod]
+        public void XElementExtensions_WithNestedQuery_FirstPathSegmentIsCorrect()
+        {
+            var path = @"/sitecore[@database='SqlServer']/events[@timingLevel=""/test/blah[a='1']""]";
+
+            var idx = path.LastPathSegmentIndex();
+            var parent = path.FirstPathSegment(idx);
+            var remainder = path.RemainingPathSegments(idx);
+
+            Assert.AreEqual(@"/sitecore[@database='SqlServer']", parent);
+            Assert.AreEqual(@"events[@timingLevel=""/test/blah[a='1']""]", remainder);
+        }
+    }
+
+}

--- a/PatchMaker/XElementExtensions.cs
+++ b/PatchMaker/XElementExtensions.cs
@@ -62,21 +62,21 @@ namespace PatchMaker
             }
 
             var idx = xPath.Length - 1;
-            var inClause = false;
+            var clauseDepth = 0;
 
             while (idx >= 0)
             {
                 var ch = xPath[idx];
                 if (ch == ']')
                 {
-                    inClause = true;
+                    clauseDepth -= 1;
                 }
                 if (ch == '[')
                 {
-                    inClause = false;
+                    clauseDepth += 1;
                 }
 
-                if (!inClause && ch == '/')
+                if (clauseDepth == 0 && ch == '/')
                 {
                     return idx;
                 }


### PR DESCRIPTION
Resolving two issues found in #49 where if the source xml included xpath queries in its attributes, the resulting patches were wrong - leading to exceptions when processing them.